### PR TITLE
Adds support for setting up SSL

### DIFF
--- a/examples/example-ssl.py
+++ b/examples/example-ssl.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+from grole import Grole
+import ssl
+
+# Create an SSL context from keys created through e.g. Let's Encrypt or self signing:
+ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+ssl_context.load_cert_chain('fullchain.pem', keyfile='privkey.pem')
+ssl_context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+
+app = Grole()
+
+@app.route('/(.*)?')
+def index(env, req):
+  return 'Is it secret? Is it safe?'
+
+app.run('0.0.0.0', port=443, ssl_context=ssl_context)

--- a/grole.py
+++ b/grole.py
@@ -19,7 +19,7 @@ import logging
 from collections import defaultdict
 
 __author__ = 'witchard'
-__version__ = '0.2.2'
+__version__ = '0.3.0'
 
 class Request:
     """
@@ -380,7 +380,7 @@ class Grole:
             self._logger.error('Connection error ({}) from {}'.format(e, peer))
             writer.close()
 
-    def run(self, host='localhost', port=1234):
+    def run(self, host='localhost', port=1234, ssl_context=None):
         """
         Launch the server. Will run forever accepting connections until interrupted.
 
@@ -388,10 +388,11 @@ class Grole:
 
             * host: The host to listen on
             * port: The port to listen on
+            * ssl_context: The SSL context passed to asyncio
         """
         # Setup loop
         loop = asyncio.get_event_loop()
-        coro = asyncio.start_server(self._handle, host, port, loop=loop)
+        coro = asyncio.start_server(self._handle, host, port, loop=loop, ssl=ssl_context)
         try:
             server = loop.run_until_complete(coro)
         except Exception as e:


### PR DESCRIPTION
This fixes https://github.com/witchard/grole/issues/16 by allowing users to create their own SSL context and passing it through Grole to the underlying asyncio:

```python
import ssl
from grole import Grole

# Create SSL context from keys create through e.g. Let's Encrypt or self signing:
ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
ssl_context.load_cert_chain('fullchain.pem', keyfile='privkey.pem')
ssl_context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1

app = Grole()
app.run('0.0.0.0', port=443, ssl_context=ssl_context)
```